### PR TITLE
Update API endpoints

### DIFF
--- a/IOSGeniusPlaza/AppDelegate.swift
+++ b/IOSGeniusPlaza/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     private func createHomeViewController() -> HomeTableViewController {
-        let movieNetworkService = NetworkService(mediaType: .movie)
+        let movieNetworkService = NetworkService(mediaType: .app)
         let movieViewModel = HomeViewModel(mediaService: movieNetworkService)
         let podCastNetworkService = NetworkService(mediaType: .podCast)
         let podCastViewModel = HomeViewModel(mediaService: podCastNetworkService)

--- a/IOSGeniusPlaza/Models/MediaType.swift
+++ b/IOSGeniusPlaza/Models/MediaType.swift
@@ -9,6 +9,6 @@
 import UIKit
 
 enum MediaType {
-    case movie
+    case app
     case podCast
 }

--- a/IOSGeniusPlaza/Models/NetworkService.swift
+++ b/IOSGeniusPlaza/Models/NetworkService.swift
@@ -29,10 +29,10 @@ struct NetworkService: MediaProtocol {
         self.session = session
         self.mediaType = mediaType
         switch mediaType {
-        case .movie:
-            mediaAPI = "https://rss.itunes.apple.com/api/v1/us/movies/top-movies/all/10/explicit.json"
+        case .app:
+            mediaAPI = "https://rss.applemarketingtools.com/api/v2/us/apps/top-free/10/apps.json"
         case .podCast:
-            mediaAPI = "https://rss.itunes.apple.com/api/v1/us/podcasts/top-podcasts/all/10/explicit.json"
+            mediaAPI = "https://rss.applemarketingtools.com/api/v2/us/podcasts/top/10/podcasts.json"
         }
     }
     

--- a/IOSGeniusPlaza/ViewModels/MediaViewModel.swift
+++ b/IOSGeniusPlaza/ViewModels/MediaViewModel.swift
@@ -33,7 +33,7 @@ class MediaViewModel {
     }
     
     func getMediaTypeString() -> NSAttributedString {
-        let text = mediaType == .movie ? "Movie" : "PodCast"
+        let text = mediaType == .app ? "Movie" : "PodCast"
         let attributedString = getAttributedString(text: text)
         return attributedString
     }

--- a/IOSGeniusPlaza/Views/HeaderView.swift
+++ b/IOSGeniusPlaza/Views/HeaderView.swift
@@ -63,7 +63,7 @@ class HeaderView: UIView {
     }()
     
     lazy var segmentedControl: UISegmentedControl = {
-        let sc = UISegmentedControl(items: ["Top 10 Movies", "Top 10 Podcast"])
+        let sc = UISegmentedControl(items: ["Top 10 Apps", "Top 10 Podcast"])
         sc.translatesAutoresizingMaskIntoConstraints = false
         sc.selectedSegmentIndex = 0
         sc.backgroundColor = .white

--- a/IOSGeniusPlazaTests/IntergrationTests.swift
+++ b/IOSGeniusPlazaTests/IntergrationTests.swift
@@ -13,7 +13,7 @@ class IntergrationTests: XCTestCase {
 
     func testShowMovieAttributedString() {
         let mockSession = MockSession()
-        let networkService = NetworkService(mediaType: .movie, session: mockSession)
+        let networkService = NetworkService(mediaType: .app, session: mockSession)
         let moviesViewModel = HomeViewModel(mediaService: networkService)
         moviesViewModel.loadMedia { (error) in
             if error != nil {

--- a/IOSGeniusPlazaTests/UnitTesting.swift
+++ b/IOSGeniusPlazaTests/UnitTesting.swift
@@ -13,7 +13,7 @@ class UnitTesting: XCTestCase {
     
     func testLoadMediaFromServer() {
         let mock = MockSession()
-        let sut = NetworkService(mediaType: .movie, session: mock)
+        let sut = NetworkService(mediaType: .app, session: mock)
         sut.loadMedia { (result) in
             switch result {
             case .failure(_):
@@ -26,7 +26,7 @@ class UnitTesting: XCTestCase {
     
     func testErrorLoadMediaFromServer() {
         let mock = MockErrorSession()
-        let sut = NetworkService(mediaType: .movie, session: mock)
+        let sut = NetworkService(mediaType: .app, session: mock)
         sut.loadMedia { (result) in
             switch result {
             case .failure(let error):


### PR DESCRIPTION
Fixed crash caused by API endpoint updates
1. https://rss.applemarketingtools.com/ removed movie option. Movie type changed to App type
2. Updated API url from v1 to v2 